### PR TITLE
Add missing license macro and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,66 @@
+# poc-driver - Linux kernel driver for Lua bindind
+
+## Compiling
+To build module you need to:
+1. Clone sources for
+Driver
+https://github.com/luainkernel/poc-driver
+Lua (kernel port)
+https://github.com/luainkernel/lunatik
+2. Download linux kernel sources and building tools (depends on your distro)
+(will assume that you have kernel tree sources in /usr/src/linux)
+3. create symlinks to lunatik and poc-driver in /usr/src/linux/drivers with corresponding names
+```
+ln -s /where_you_put_lunatik_src /usr/src/linux/drivers/lunatik
+ln -s /where_you_put_poc-driver_src /usr/src/linux/drivers/poc-driver
+```
+4. edit drivers/Kconfig to add following:
+```
+source drivers/lunatik/Kconfig
+```
+5. lunatik/Kconfig contents:
+```
+config LUNATIK
+    tristate "Lunatik"
+    
+config LUNATIK_POC
+    bool "Use poc driver"
+    depends on LUNATIK
+    default y
+```
+6. edit drivers/Makefile to add:
+```
+obj-$(CONFIG_LUNATIK) += lunatik/
+```
+7. lunatik/Makefile example code:
+```
+EXTRA_CFLAGS += -D_KERNEL
+# for poc-driver:
+EXTRA_CFLAGS += -I$(src)
+
+obj-$(CONFIG_LUNATIK) += lunatik.o
+
+lunatik-objs := lua/lapi.o lua/lcode.o lua/lctype.o lua/ldebug.o lua/ldo.o \
+         lua/ldump.o lua/lfunc.o lua/lgc.o lua/llex.o lua/lmem.o \
+	 lua/lobject.o lua/lopcodes.o lua/lparser.o lua/lstate.o \
+         lua/lstring.o lua/ltable.o lua/ltm.o \
+	 lua/lundump.o lua/lvm.o lua/lzio.o lua/lauxlib.o lua/lbaselib.o \
+         lua/lbitlib.o lua/lcorolib.o lua/ldblib.o lua/lstrlib.o \
+	 lua/ltablib.o lua/lutf8lib.o lua/loslib.o lua/lmathlib.o lua/linit.o
+
+lunatik-objs += arch/$(ARCH)/setjmp.o
+
+lunatik-${CONFIG_LUNATIK_POC} += ../poc-driver/luadev.o
+```
+8. Then:
+```
+cd /usr/src/linux
+#compile
+make modules -j4 ARCH=x86_64
+#load
+modprobe -v lunatik
+#test
+cat helloworld.lua > /dev/luadrv
+```
+9. EOF\0 ;)
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# poc-driver - Linux kernel driver for Lua bindind
+# poc-driver - Linux kernel driver for lunatik
 
 ## Compiling
 To build module you need to:
@@ -7,8 +7,7 @@ Driver
 https://github.com/luainkernel/poc-driver
 Lua (kernel port)
 https://github.com/luainkernel/lunatik
-2. Download linux kernel sources and building tools (depends on your distro)
-(will assume that you have kernel tree sources in /usr/src/linux)
+2. Assume that you have kernel tree sources in /usr/src/linux
 3. create symlinks to lunatik and poc-driver in /usr/src/linux/drivers with corresponding names
 ```
 ln -s /where_you_put_lunatik_src /usr/src/linux/drivers/lunatik
@@ -59,8 +58,22 @@ cd /usr/src/linux
 make modules -j4 ARCH=x86_64
 #load
 modprobe -v lunatik
-#test
+```
+
+## Usage
+
+Loaded driver usage:
+
+Example script helloworld.lua:
+```
+print("Hello, World!")
+```
+
+Terminal:
+```
 cat helloworld.lua > /dev/luadrv
 ```
-9. EOF\0 ;)
+then check dmesg for message
+
+
 

--- a/luadev.c
+++ b/luadev.c
@@ -5,11 +5,15 @@
 #include <linux/string.h>
 #include <linux/device.h>
 #include <linux/cdev.h>
-#include <asm/uaccess.h>
-#define _KERNEL
+//#include <asm/uaccess.h>
+//#define _KERNEL
+#include <linux/uaccess.h>
+
 #include <lua/lua.h>
 #include <lua/lualib.h>
 #include <lua/lauxlib.h>
+
+MODULE_LICENSE("GPL");
 
 #define DEVICE_NAME "luadrv"
 #define CLASS_NAME "lua"

--- a/luadev.c
+++ b/luadev.c
@@ -5,15 +5,13 @@
 #include <linux/string.h>
 #include <linux/device.h>
 #include <linux/cdev.h>
-//#include <asm/uaccess.h>
-//#define _KERNEL
 #include <linux/uaccess.h>
 
 #include <lua/lua.h>
 #include <lua/lualib.h>
 #include <lua/lauxlib.h>
 
-MODULE_LICENSE("GPL");
+MODULE_LICENSE("Dual MIT/GPL");
 
 #define DEVICE_NAME "luadrv"
 #define CLASS_NAME "lua"


### PR DESCRIPTION
0. Fix from @tcz717 added to driver (need to compile)
1. I've added missing license macro in kernel module.
Without that macros some symbols not available in module and we got problems:
```
[130.947891] lunatik: module license 'unspecified' taints kernel.
[  130.947894] Disabling lock debugging due to kernel taint
[ 3195.333547] lunatik: Unknown symbol __class_create (err 0)
```
2. I've decided to add some README with simple instructions